### PR TITLE
Improve on how to get a branch name

### DIFF
--- a/helm-ls-git.el
+++ b/helm-ls-git.el
@@ -152,17 +152,16 @@ Valid values are symbol 'abs (default) or 'relative."
     (helm-init-candidates-in-buffer 'global data)))
 
 (defun helm-ls-git-header-name (name)
-  (let ((refs   (shell-command-to-string "git rev-parse --branches"))
-        (branch (shell-command-to-string
-                 "git rev-parse --abbrev-ref HEAD")))
-    (format "%s (%s)"
-            name
-            (replace-regexp-in-string
-             "\n" ""
-             ;; Check REFS to avoid message error in header
-             ;; when repo is just initialized and there is
-             ;; no branches yet.
-             (if (or (null refs) (string= refs "")) "--" branch)))))
+  (format "%s (%s)"
+          name
+          (with-temp-buffer
+            (let ((ret (call-process-shell-command "git symbolic-ref --short HEAD" nil t)))
+              ;; Use sha of HEAD when branch name is missing.
+              (unless (zerop ret)
+                (erase-buffer)
+                (call-process-shell-command "git rev-parse --short HEAD" nil t)))
+            (buffer-substring-no-properties (goto-char (point-min))
+                                            (line-end-position)))))
 
 (defun helm-ls-git-actions-list ()
   (let ((actions (helm-actions-from-type-file)))


### PR DESCRIPTION
Improve on how to get a branch name by reducing the frequency of executing shell commands.

I feel it's slow to execute a shell command **always twice** in order to get a branch name, and it's actually slow as far as I profiled.
So I reduce the frequency of executing shell commands referring to [oh-my-zsh's git plugin](//github.com/robbyrussell/oh-my-zsh/blob/master/lib/git.zsh#L4-L5).
### Profiling steps
1. Open a file in a clean git repository.
2. <kbd>M-x elp-instrument-package RET helm-ls-git RET</kbd>
3. <kbd>M-x elp-instrument-function RET shell-command-to-string RET</kbd>
4. <kbd>M-x helm-ls-git-ls</kbd>
5. <kbd>C-g</kbd> after `helm-ls-git-ls` results are displayed.
6. <kbd>M-x elp-results</kdb>
### Profiling results
#### before

```
helm-ls-git-ls                         1           1.720472      1.720472
helm-ls-git-header-name                1           1.3683969999  1.3683969999
shell-command-to-string                2           1.367515      0.6837575
helm-ls-git-status                     1           0.008327      0.008327
helm-ls-git-init                       1           0.007876      0.007876
helm-ls-git-list-files                 1           0.007291      0.007291
helm-ls-git-root-dir                   3           0.000319      0.0001063333
helm-ls-git-transformer                1           0.000119      0.000119
helm-ls-git-status-transformer         1           6.4e-05       6.4e-05
helm-ls-git-sort-fn                    1           1.8e-05       1.8e-05
```
#### after

```
helm-ls-git-ls                         1           1.049938      1.049938
helm-ls-git-header-name                1           0.673281      0.673281
call-process-shell-command             1           0.673149      0.673149
helm-ls-git-status                     1           0.008407      0.008407
helm-ls-git-init                       1           0.006931      0.006931
helm-ls-git-list-files                 1           0.006734      0.006734
helm-ls-git-root-dir                   3           0.00026       8.666...e-05
helm-ls-git-transformer                1           0.000124      0.000124
helm-ls-git-status-transformer         1           6.4e-05       6.4e-05
helm-ls-git-sort-fn                    1           2.1e-05       2.1e-05
```
