### PR TITLE
Fix the switch that enables relative paths

### DIFF
--- a/helm-ls-git.el
+++ b/helm-ls-git.el
@@ -160,7 +160,7 @@ The color of matched items can be customized in your .gitconfig."
                            (helm-basename i)
                            (cl-case helm-ls-git-show-abs-or-relative
                              (absolute abs)
-                             (relative i)))
+                             (relative (file-relative-name i root))))
             collect
             (cons (propertize disp 'face 'helm-ff-file) abs)))
 


### PR DESCRIPTION
The switch seems to have been broken when reverting some broken functionality.

See my comments in https://github.com/emacs-helm/helm-ls-git/issues/21 for more info.