### PR TITLE
Don't init candidates when not inside a git repo.

### DIFF
--- a/helm-ls-git.el
+++ b/helm-ls-git.el
@@ -170,20 +170,22 @@ The color of matched items can be customized in your .gitconfig."
   (helm-ff-sort-candidates candidates nil))
 
 (defun helm-ls-git-init ()
-  (let ((data (cl-loop with root = (helm-ls-git-root-dir)
-                       for c in (split-string (helm-ls-git-list-files) "\n" t)
-                       collect (expand-file-name c root))))
-    (when (null data)
-      (setq data
-            (if helm-ls-git-log-file
-                (with-current-buffer
-                    (find-file-noselect helm-ls-git-log-file)
-                  (prog1
-                      (buffer-substring-no-properties
-                       (point-min) (point-max))
-                    (kill-buffer)))
-              data)))
-    (helm-init-candidates-in-buffer 'global data)))
+  (let ((git-root (helm-ls-git-root-dir)))
+    (when git-root
+      (let ((data (cl-loop for c in (split-string (helm-ls-git-list-files) "\n" t)
+                           collect (expand-file-name c git-root))))
+        (when (null data)
+          (setq data
+                (if helm-ls-git-log-file
+                    (with-current-buffer
+                        (find-file-noselect helm-ls-git-log-file)
+                      (prog1
+                          (buffer-substring-no-properties
+                           (point-min) (point-max))
+                        (kill-buffer)))
+                  data)))
+        (helm-init-candidates-in-buffer 'global data)))))
+
 
 (defun helm-ls-git-header-name (name)
   (format "%s (%s)"


### PR DESCRIPTION
I'm using helm-ls-git as a source also outside git repos and would like to to gracefully fail (ie, don't display any candidates). Not sure where this behavior changed along the way, #3 suggests that this is generally intended behavior?