### PR TITLE
Utilize double quotes for git-grep globs.

### DIFF
--- a/helm-ls-git.el
+++ b/helm-ls-git.el
@@ -320,7 +320,7 @@ and launch git-grep from there.
   (let* ((helm-grep-default-command helm-ls-git-grep-command)
          helm-grep-default-recurse-command
          (files (cond ((equal helm-current-prefix-arg '(4))
-                       (list (format "'%s'" (mapconcat
+                       (list (format "\"%s\"" (mapconcat
                                              'identity
                                              (helm-grep-get-file-extensions
                                               (helm-marked-candidates))


### PR DESCRIPTION
Do this because my git-grep is sensitive to the type of quotes the glob is enclosed in.  I'm running Windows though, so I'm likely the edge case.

I'm testing this ~monkey patched like this:
```elisp
(defun helm-ls-git-grep-monkey (_candidate)
  (let* ((helm-grep-default-command helm-ls-git-grep-command)
         helm-grep-default-recurse-command
         (files (cond ((equal helm-current-prefix-arg '(4))
                       (list (format "\"%s\"" (mapconcat
                                             'identity
                                             (helm-grep-get-file-extensions
                                              (helm-marked-candidates))
                                             " "))))
                      ((equal helm-current-prefix-arg '(16))
                       '(""))
                      (t (helm-marked-candidates))))
         ;; Expand filename of each candidate with the git root dir.
         ;; The filename will be in the help-echo prop.
         (helm-grep-default-directory-fn 'helm-ls-git-root-dir)
         ;; set `helm-ff-default-directory' to the root of project.
         (helm-ff-default-directory (helm-ls-git-root-dir)))
    (helm-do-grep-1 files)))

(defun helm-ls-git-run-grep-monkey ()
  "Run Git Grep action from helm-ls-git."
  (interactive)
  (with-helm-alive-p
    (helm-exit-and-execute-action 'helm-ls-git-grep-monkey)))

(define-key helm-ls-git-map (kbd "C-m") 'helm-ls-git-run-grep-monkey)
```

Works correctly for me now.