### PR TITLE
Allow optional passing of default input into helm-ls-git-ls function

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ to the `current-buffer`:
 M-x `helm-find-files`
 navigate to some git repo and hit `C-x C-d`
 
+
+You can also invoke `helm-ls-git-ls` through those two utility functions while browsing source code in a buffer :
+        
+```elisp
+(global-set-key (kbd "C-x <f6>") 'helm-ls-git-at-point)
+```
+
+```elisp
+(define-key isearch-mode-map (kbd "<f6>") 'helm-ls-git-from-isearch)
+```
+        
 ## Usage
 
 * By calling `helm-ls-git-ls` or `helm-browse-project` in any buffer that is a part of a git

--- a/helm-ls-git.el
+++ b/helm-ls-git.el
@@ -482,7 +482,7 @@ and launch git-grep from there.
              1)))))
 
 ;;;###autoload
-(defun helm-ls-git-ls (&optional arg)
+(defun helm-ls-git-ls (&optional arg &optional input) 
   (interactive "p")
   (when (and arg (helm-ls-git-not-inside-git-repo))
     (error "Not inside a Git repository"))
@@ -505,8 +505,32 @@ and launch git-grep from there.
   (helm-set-local-variable 'helm-ls-git--current-branch (helm-ls-git--branch))
   (helm :sources helm-ls-git-default-sources
         :ff-transformer-show-only-basename nil
+        :input input 
         :buffer "*helm lsgit*"))
 
+(defun helm-ls-git-at-point() 
+  "Invoke `helm-ls-git-ls' with symbol at point. 
+ 
+Use region as input instead of the thing at point 
+if region exists. 
+" 
+  (interactive) 
+  (let* ((symbol (if (not mark-active) (thing-at-point 'symbol) 
+                   (when (use-region-p) (buffer-substring (region-beginning) (region-end))))) 
+         (input (if symbol (concat symbol " ") nil))) 
+    (when mark-active 
+      (deactivate-mark)) ;; remove any active regions 
+    (helm-ls-git-ls nil input) 
+    )) 
+
+(defun helm-ls-git-from-isearch() 
+  "Invoke `helm-ls-git-ls' from isearch." 
+  (interactive) 
+  (let ((input (if isearch-regexp 
+                   isearch-string 
+                 (regexp-quote isearch-string)))) 
+    (isearch-exit) 
+    (helm-ls-git-ls nil input))) 
 
 (provide 'helm-ls-git)
 


### PR DESCRIPTION
Also added two functions (helm-ls-git-at-point, helm-ls-git-from-isearch) which use the new parameter for jumping directly to the corresponding file while browsing source code.

NB : I know almost nothing about elisp, this is just the same behaviour that you can get from helm-git-grep ported to helm-ls-git through some copy pasting.
I found this behaviour really useful for browsing large OOP projects where class names often match file names.
