### PR TITLE
Match helm-buffers-truncate-lines in helm-ls-git sources

### DIFF
--- a/helm-ls-git.el
+++ b/helm-ls-git.el
@@ -718,6 +718,7 @@ Do nothing when `helm-source-ls-git-buffers' is not member of
     (helm-set-local-variable 'helm-ls-git--current-branch (helm-ls-git--branch))
     (helm :sources helm-ls-git-default-sources
           :ff-transformer-show-only-basename nil
+          :truncate-lines helm-buffers-truncate-lines
           :buffer "*helm lsgit*")))
 
 


### PR DESCRIPTION
helm-ls-git-default-sources contains a buffer source that should be truncated according helm-buffers-truncate-lines. If a user wants to truncate buffer sources it should be applied everywhere.