### PR TITLE
Change suggested helm-ls-git-status-command for magit users

### DIFF
--- a/helm-ls-git.el
+++ b/helm-ls-git.el
@@ -66,7 +66,7 @@ Valid values are symbol 'absolute or 'relative (default)."
 (defcustom helm-ls-git-status-command 'vc-dir
   "Favorite git-status command for emacs.
 
-If you want to use magit use `magit-status-internal' and not
+If you want to use magit use `magit-status-setup-buffer' and not
 `magit-status' which is working only interactively."
   :group 'helm-ls-git
   :type 'symbol)


### PR DESCRIPTION
magit-status-internal is obselete in the forthcoming Magit 3.0.0.


----

#