### PR TITLE
Fix inhibit-magit-refresh obsolete warning.

### DIFF
--- a/helm-ls-git.el
+++ b/helm-ls-git.el
@@ -607,7 +607,7 @@ See docstring of `helm-ls-git-ls-switches'.
   (require 'magit-commit nil t)
   (let ((default-directory (file-name-directory candidate)))
     (if (fboundp 'magit-commit-extend)
-        (let ((inhibit-magit-refresh t))
+        (let ((magit-inhibit-refresh t))
           (magit-commit-extend))
       (process-file "git" nil nil nil "commit" "--amend" "--no-edit"))))
 
@@ -615,7 +615,7 @@ See docstring of `helm-ls-git-ls-switches'.
   (require 'magit-commit nil t)
   (let ((default-directory (file-name-directory candidate)))
     (if (fboundp 'magit-commit-amend)
-        (let ((inhibit-magit-refresh t))
+        (let ((magit-inhibit-refresh t))
           (magit-commit-amend))
       (process-file "git" nil nil nil "commit" "--amend"))))
 
@@ -624,7 +624,7 @@ See docstring of `helm-ls-git-ls-switches'.
   (require 'magit-commit nil t)
   (let ((default-directory (file-name-directory candidate)))
     (if (fboundp 'magit-commit)
-        (let ((inhibit-magit-refresh t))
+        (let ((magit-inhibit-refresh t))
           (magit-commit))
       (helm-ls-git-commit-files))))
 


### PR DESCRIPTION
Nothing special, just a small tidy fix to adapt to magit 3.0 and silence byte compiler.