### PR TITLE
Fix byte compiler warning magit-commit interactive use only.

### DIFF
--- a/helm-ls-git.el
+++ b/helm-ls-git.el
@@ -625,7 +625,7 @@ See docstring of `helm-ls-git-ls-switches'.
   (let ((default-directory (file-name-directory candidate)))
     (if (fboundp 'magit-commit)
         (let ((inhibit-magit-refresh t))
-          (magit-commit))
+          (call-interactively 'magit-commit))
       (helm-ls-git-commit-files))))
 
 (defun helm-ls-git-commit-files ()


### PR DESCRIPTION
Another small fix to silence the byte compiler.