### PR TITLE
Fix/magit commit

### DIFF
--- a/helm-ls-git.el
+++ b/helm-ls-git.el
@@ -625,7 +625,7 @@ See docstring of `helm-ls-git-ls-switches'.
   (let ((default-directory (file-name-directory candidate)))
     (if (fboundp 'magit-commit)
         (let ((inhibit-magit-refresh t))
-          (magit-commit))
+          (call-interactively 'magit-commit))
       (helm-ls-git-commit-files))))
 
 (defun helm-ls-git-commit-files ()


### PR DESCRIPTION
So now :-), I think this one will work too, since we are anyway calling an interactive function from Helm, we can as well call it interactively, so we skip that warning from the byte compiler? 