### PR TITLE
Simplified helm-ls-git-root-dir

### DIFF
--- a/helm-ls-git.el
+++ b/helm-ls-git.el
@@ -293,9 +293,8 @@ See docstring of `helm-ls-git-ls-switches'.
     (helm-force-update)))
 (put 'helm-ls-git-ls-switches 'helm-only t)
 
-(cl-defun helm-ls-git-root-dir (&optional (directory default-directory))
-  (let ((root (locate-dominating-file directory ".git")))
-    (and root (file-name-as-directory root))))
+(defun helm-ls-git-root-dir (&optional directory)
+  (locate-dominating-file directory (or directory default-directory)) ".git")
 
 (defun helm-ls-git-not-inside-git-repo ()
   (not (helm-ls-git-root-dir)))


### PR DESCRIPTION
locate-dominating-file will give you nil if it can't find the file and if it can it will return directory name. and wiill just test if it got nil and return nil and file-name-as-directory will just test for the slash at the end of that directory name, but are needless, just return what locate-dominating-file gives you directrly and save unnecessary let-closure and comparisons.